### PR TITLE
Fix version listing format in list-all script.

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -14,5 +14,5 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval "$cmd" | grep -oE "tag_name\": \".{1,20}\"," | sed 's/tag_name\": \"//;s/\",//' | sort_versions)
+versions=$(eval "$cmd" | grep -oE "tag_name\": \".{1,20}\"," | sed 's/tag_name\": \"//;s/\",//' | sort_versions | tr '\n' ' ')
 echo "$versions"


### PR DESCRIPTION
Currently the script outputs each version on a new line, whereas asdf seems to require versions to be space-delimited. This change replaces newlines in the output with spaces.